### PR TITLE
DT-474/tap-chargebee-schemaless

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This tap:
   - [Virtual Bank Accounts](https://apidocs.chargebee.com/docs/api/virtual_bank_accounts)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
+- Use `schemaless` variable to pull data without aligning with input schema 
 
 ## Quick Start
 

--- a/tap_chargebee/__init__.py
+++ b/tap_chargebee/__init__.py
@@ -13,18 +13,21 @@ class ChargebeeRunner(tap_framework.Runner):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     args = singer.utils.parse_args(
-        required_config_keys=['api_key', 'start_date'])
+        required_config_keys=["api_key", "start_date", "schemaless"]
+    )
 
-    full_site = args.config.get('full_site', None)
-    
-    product_catalog = args.config.get('product_catalog', '1.0')
+    full_site = args.config.get("full_site", None)
 
-    site = args.config.get('site', None)
+    product_catalog = args.config.get("product_catalog", "1.0")
+
+    site = args.config.get("site", None)
     if full_site is None and site is None:
-        raise Exception("Config is missing required key: atleast one key 'site' or 'full_site' is required")
+        raise Exception(
+            "Config is missing required key: atleast one key 'site' or 'full_site' is required"
+        )
 
     if full_site is None:
-        args.config['full_site'] = f"{site}.chargebee.com"
+        args.config["full_site"] = f"{site}.chargebee.com"
 
     client = tap_chargebee.client.ChargebeeClient(args.config)
 
@@ -32,12 +35,13 @@ def main():
     if args.discover:
         available_streams = tap_chargebee.streams.AVAILABLE_STREAMS_ALL
     else:
-        available_streams = tap_chargebee.streams.AVAILABLE_STREAMS_2_0 if product_catalog == "2.0" else tap_chargebee.streams.AVAILABLE_STREAMS_1_0
-
-
-    runner = ChargebeeRunner(
-        args, client, available_streams
+        available_streams = (
+            tap_chargebee.streams.AVAILABLE_STREAMS_2_0
+            if product_catalog == "2.0"
+            else tap_chargebee.streams.AVAILABLE_STREAMS_1_0
         )
+
+    runner = ChargebeeRunner(args, client, available_streams)
 
     if args.discover:
         runner.do_discover()
@@ -45,5 +49,5 @@ def main():
         runner.do_sync()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tap_chargebee/streams/base.py
+++ b/tap_chargebee/streams/base.py
@@ -1,119 +1,121 @@
+import datetime
 import singer
 import time
 import json
 import os
 
+from singer.utils import strftime, strptime_to_utc
 from .util import Util
 from dateutil.parser import parse
 from tap_framework.streams import BaseStream
 from tap_framework.schemas import load_schema_by_name
 from tap_framework.config import get_config_start_date
-from tap_chargebee.state import get_last_record_value_for_table, incorporate, \
-    save_state
+from tap_chargebee.state import get_last_record_value_for_table, incorporate, save_state
 
 LOGGER = singer.get_logger()
 
 
 class BaseChargebeeStream(BaseStream):
-
     def write_schema(self):
         singer.write_schema(
             self.catalog.stream,
             self.catalog.schema.to_dict(),
             key_properties=self.KEY_PROPERTIES,
-            bookmark_properties=self.BOOKMARK_PROPERTIES)
+            bookmark_properties=self.BOOKMARK_PROPERTIES,
+        )
 
     def generate_catalog(self):
         schema = self.get_schema()
         mdata = singer.metadata.new()
 
         metadata = {
-
             "forced-replication-method": self.REPLICATION_METHOD,
             "valid-replication-keys": self.VALID_REPLICATION_KEYS,
             "inclusion": self.INCLUSION,
-            #"selected-by-default": self.SELECTED_BY_DEFAULT,
-            "table-key-properties": self.KEY_PROPERTIES
+            # "selected-by-default": self.SELECTED_BY_DEFAULT,
+            "table-key-properties": self.KEY_PROPERTIES,
         }
 
         for k, v in metadata.items():
-            mdata = singer.metadata.write(
-                mdata,
-                (),
-                k,
-                v
-            )
+            mdata = singer.metadata.write(mdata, (), k, v)
 
-        for field_name, field_schema in schema.get('properties').items():
-            inclusion = 'available'
+        for field_name, field_schema in schema.get("properties").items():
+            inclusion = "available"
 
-            if field_name in self.KEY_PROPERTIES or field_name in self.BOOKMARK_PROPERTIES:
-                inclusion = 'automatic'
+            if (
+                field_name in self.KEY_PROPERTIES
+                or field_name in self.BOOKMARK_PROPERTIES
+            ):
+                inclusion = "automatic"
 
             mdata = singer.metadata.write(
-                mdata,
-                ('properties', field_name),
-                'inclusion',
-                inclusion
+                mdata, ("properties", field_name), "inclusion", inclusion
             )
 
         cards = singer.utils.load_json(
             os.path.normpath(
                 os.path.join(
-                    self.get_class_path(),
-                    '../schemas/{}.json'.format("cards"))))
+                    self.get_class_path(), "../schemas/{}.json".format("cards")
+                )
+            )
+        )
 
         refs = {"cards.json": cards}
 
-        return [{
-            'tap_stream_id': self.TABLE,
-            'stream': self.TABLE,
-            'schema': singer.resolve_schema_references(schema, refs),
-            'metadata': singer.metadata.to_list(mdata)
-        }]
+        return [
+            {
+                "tap_stream_id": self.TABLE,
+                "stream": self.TABLE,
+                "schema": singer.resolve_schema_references(schema, refs),
+                "metadata": singer.metadata.to_list(mdata),
+            }
+        ]
 
     def appendCustomFields(self, record):
-        listOfCustomFieldObj = ['addon', 'plan', 'subscription', 'customer', 'item']
+        listOfCustomFieldObj = ["addon", "plan", "subscription", "customer", "item"]
         custom_fields = {}
         event_custom_fields = {}
-        if self.ENTITY == 'event':
-            content = record['content']
-            words = record['event_type'].split("_")
+        if self.ENTITY == "event":
+            content = record["content"]
+            words = record["event_type"].split("_")
             sl = slice(len(words) - 1)
-            content_obj = "_".join(words[sl])     
-            
+            content_obj = "_".join(words[sl])
+
             if content_obj in listOfCustomFieldObj:
-                for k in record['content'][content_obj].keys():
+                for k in record["content"][content_obj].keys():
                     if "cf_" in k:
-                        event_custom_fields[k] = record['content'][content_obj][k]
-                record['content'][content_obj]['custom_fields'] = json.dumps(event_custom_fields)    
-        
+                        event_custom_fields[k] = record["content"][content_obj][k]
+                record["content"][content_obj]["custom_fields"] = json.dumps(
+                    event_custom_fields
+                )
 
         for key in record.keys():
             if "cf_" in key:
                 custom_fields[key] = record[key]
         if custom_fields:
-            record['custom_fields'] = json.dumps(custom_fields)
+            record["custom_fields"] = json.dumps(custom_fields)
         return record
 
     # This overrides the transform_record method in the Fistown Analytics tap-framework package
     def transform_record(self, record):
-        with singer.Transformer(integer_datetime_fmt="unix-seconds-integer-datetime-parsing") as tx:
+        with singer.Transformer(
+            integer_datetime_fmt="unix-seconds-integer-datetime-parsing"
+        ) as tx:
             metadata = {}
-            
+
             record = self.appendCustomFields(record)
-                
+
             if self.catalog.metadata is not None:
                 metadata = singer.metadata.to_map(self.catalog.metadata)
 
-            return tx.transform(
-                record,
-                self.catalog.schema.to_dict(),
-                metadata)
+            return tx.transform(record, self.catalog.schema.to_dict(), metadata)
 
     def get_stream_data(self, data):
         entity = self.ENTITY
-        return [self.transform_record(item.get(entity)) for item in data]
+        if self.config.get("schemaless", False):
+            return [item.get(entity) for item in data]
+        else:
+            return [self.transform_record(item.get(entity)) for item in data]
 
     def sync_data(self):
         table = self.TABLE
@@ -121,12 +123,20 @@ class BaseChargebeeStream(BaseStream):
         done = False
 
         # Attempt to get the bookmark date from the state file (if one exists and is supplied).
-        LOGGER.info('Attempting to get the most recent bookmark_date for entity {}.'.format(self.ENTITY))
-        bookmark_date = get_last_record_value_for_table(self.state, table, 'bookmark_date')
+        LOGGER.info(
+            "Attempting to get the most recent bookmark_date for entity {}.".format(
+                self.ENTITY
+            )
+        )
+        bookmark_date = get_last_record_value_for_table(
+            self.state, table, "bookmark_date"
+        )
 
         # If there is no bookmark date, fall back to using the start date from the config file.
         if bookmark_date is None:
-            LOGGER.info('Could not locate bookmark_date from STATE file. Falling back to start_date from config.json instead.')
+            LOGGER.info(
+                "Could not locate bookmark_date from STATE file. Falling back to start_date from config.json instead."
+            )
             bookmark_date = get_config_start_date(self.config)
         else:
             bookmark_date = parse(bookmark_date)
@@ -135,18 +145,18 @@ class BaseChargebeeStream(BaseStream):
         bookmark_date_posix = int(bookmark_date.timestamp())
 
         # Create params for filtering
-        if self.ENTITY == 'event':
+        if self.ENTITY == "event":
             params = {"occurred_at[after]": bookmark_date_posix}
-            bookmark_key = 'occurred_at'
-        elif self.ENTITY == 'promotional_credit':
+            bookmark_key = "occurred_at"
+        elif self.ENTITY == "promotional_credit":
             params = {"created_at[after]": bookmark_date_posix}
-            bookmark_key = 'created_at'
-        elif self.ENTITY == 'unbilled_charge':
+            bookmark_key = "created_at"
+        elif self.ENTITY == "unbilled_charge":
             params = {}
             bookmark_key = None
         else:
             params = {"updated_at[after]": bookmark_date_posix}
-            bookmark_key = 'updated_at'
+            bookmark_key = "updated_at"
 
         LOGGER.info("Querying {} starting at {}".format(table, bookmark_date))
 
@@ -154,38 +164,36 @@ class BaseChargebeeStream(BaseStream):
             max_date = bookmark_date
 
             response = self.client.make_request(
-                url=self.get_url(),
-                method=api_method,
-                params=params)
+                url=self.get_url(), method=api_method, params=params
+            )
 
-            if 'api_error_code' in response.keys():
-                if response['api_error_code'] == 'configuration_incompatible':
-                    LOGGER.error('{} is not configured'.format(response['error_code']))
+            if "api_error_code" in response.keys():
+                if response["api_error_code"] == "configuration_incompatible":
+                    LOGGER.error("{} is not configured".format(response["error_code"]))
                     break
 
-            records = response.get('list')
-            
+            records = response.get("list")
+
             to_write = self.get_stream_data(records)
-            
-            if self.ENTITY == 'event':
+
+            if self.ENTITY == "event":
                 for event in to_write:
-                    if event["event_type"] == 'plan_deleted':
-                        Util.plans.append(event['content']['plan'])
-                    elif event['event_type'] == 'addon_deleted':
-                        Util.addons.append(event['content']['addon'])
-                    elif event['event_type'] == 'coupon_deleted':
-                        Util.coupons.append(event['content']['coupon'])
-            if self.ENTITY == 'plan':
+                    if event["event_type"] == "plan_deleted":
+                        Util.plans.append(event["content"]["plan"])
+                    elif event["event_type"] == "addon_deleted":
+                        Util.addons.append(event["content"]["addon"])
+                    elif event["event_type"] == "coupon_deleted":
+                        Util.coupons.append(event["content"]["coupon"])
+            if self.ENTITY == "plan":
                 for plan in Util.plans:
                     to_write.append(plan)
-            if self.ENTITY == 'addon':
+            if self.ENTITY == "addon":
                 for addon in Util.addons:
                     to_write.append(addon)
-            if self.ENTITY == 'coupon':
+            if self.ENTITY == "coupon":
                 for coupon in Util.coupons:
-                    to_write.append(coupon) 
+                    to_write.append(coupon)
 
-            
             with singer.metrics.record_counter(endpoint=table) as ctr:
                 singer.write_records(table, to_write)
 
@@ -193,22 +201,29 @@ class BaseChargebeeStream(BaseStream):
 
                 if bookmark_key is not None:
                     for item in to_write:
-                        #if item.get(bookmark_key) is not None:
-                        max_date = max(
-                            max_date,
-                            parse(item.get(bookmark_key))
-                        )
+                        parsed_date = None
+                        if self.config.get("schemaless", False):
+                            parsed_date = parse(
+                                strftime(
+                                    datetime.datetime.fromtimestamp(
+                                        int(item.get(bookmark_key)),
+                                        datetime.timezone.utc,
+                                    )
+                                )
+                            )
+                        else:
+                            parsed_date = parse(item.get(bookmark_key))
+                        max_date = max(max_date, parsed_date)
 
             if bookmark_key is not None:
-                self.state = incorporate(
-                    self.state, table, 'bookmark_date', max_date)
+                self.state = incorporate(self.state, table, "bookmark_date", max_date)
 
-            if not response.get('next_offset'):
+            if not response.get("next_offset"):
                 LOGGER.info("Final offset reached. Ending sync.")
                 done = True
             else:
                 LOGGER.info("Advancing by one offset.")
-                params['offset'] = response.get('next_offset')
+                params["offset"] = response.get("next_offset")
                 bookmark_date = max_date
 
         save_state(self.state)


### PR DESCRIPTION
Use `schemaless` variable to pull data without aligning with input schema

# Description of change
The currently available tap-chargebee uses a pre-fixed schema to extract/load data, here the goal is to override this schema in order to be able to communicate data, from tap to target, without having to align with a pre-established schema and thus have more flexibility.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
